### PR TITLE
S UI t 46 스터디 그룹 미션 달성 요청/승인

### DIFF
--- a/src/main/java/com/suite/suite_study_service/common/handler/StatusCode.java
+++ b/src/main/java/com/suite/suite_study_service/common/handler/StatusCode.java
@@ -8,7 +8,7 @@ public enum StatusCode {
 
     DISABLED_ACCOUNT(403, "삭제된 계정입니다.", HttpStatus.FORBIDDEN),
     DORMANT_ACCOUNT(423, "이 계정은 휴먼 계정입니다.", HttpStatus.LOCKED),
-    ALREADY_EXISTS_SUITEROOM(400, "이미 존재하는 스위트룸입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXISTS_MISSION(400, "이미 생성됐던 미션 이름입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_EXISTS_PARTICIPANT(400, "이미 참여중 입니다.", HttpStatus.BAD_REQUEST),
     CAN_NOT_CALCEL_SUITEROOM(400, "스위트룸 참가 취소를 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_DELETE_SUITE_ROOM(400, "시작된 스터디는 삭제가 불가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/suite/suite_study_service/dashboard/repository/DashBoardRepository.java
+++ b/src/main/java/com/suite/suite_study_service/dashboard/repository/DashBoardRepository.java
@@ -10,4 +10,6 @@ public interface DashBoardRepository extends JpaRepository<DashBoard, Long> {
     List<DashBoard> findAllBySuiteRoomId(Long suiteRoomId);
     Optional<DashBoard> findByMemberId(Long memberId);
 
+    Optional<DashBoard> findBySuiteRoomIdAndMemberId(Long suiteRoomId, Long memberId);
+
 }

--- a/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
+++ b/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
@@ -31,6 +31,11 @@ public class MissionController {
         return ResponseEntity.ok(new Message(StatusCode.OK,missionService.getMissions(reqMissionListDto)));
     }
 
+    @PostMapping("/mission/admin")
+    public ResponseEntity<Message> listUpRequestedMissions(@RequestBody ReqMissionListDto reqMissionListDto) {
+        return ResponseEntity.ok(new Message(StatusCode.OK,missionService.getRequestedMissions(reqMissionListDto)));
+    }
+
     @PostMapping("/mission/submission")
     public ResponseEntity<Message> requestApprovalMission(@RequestBody ReqMissionApprovalDto reqMissionApprovalDto) {
         missionService.updateMissionStatusProgressToChecking(reqMissionApprovalDto);

--- a/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
+++ b/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
@@ -2,6 +2,7 @@ package com.suite.suite_study_service.mission.controller;
 
 import com.suite.suite_study_service.common.dto.Message;
 import com.suite.suite_study_service.common.handler.StatusCode;
+import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionListDto;
 import com.suite.suite_study_service.mission.service.MissionService;
@@ -27,7 +28,18 @@ public class MissionController {
 
     @PostMapping("/mission")
     public ResponseEntity<Message> listUpMissions(@RequestBody ReqMissionListDto reqMissionListDto) {
-        return ResponseEntity.ok(new Message(StatusCode.OK,missionService.listUpMission(reqMissionListDto.getSuiteRoomId(), reqMissionListDto.getMissionTypeString())));
+        return ResponseEntity.ok(new Message(StatusCode.OK,missionService.listUpMission(reqMissionListDto)));
+    }
+
+    @PostMapping("/mission/submission")
+    public ResponseEntity<Message> requestApprovalMission(@RequestBody ReqMissionApprovalDto reqMissionApprovalDto) {
+        missionService.updateMissionStatusProgressToChecking(reqMissionApprovalDto);
+        return ResponseEntity.ok(new Message(StatusCode.OK));
+    }
+    @PostMapping("/mission/approval")
+    public ResponseEntity<Message> approvalRequestAcceptMission(@RequestBody ReqMissionApprovalDto reqMissionApprovalDto) {
+        missionService.updateMissionStatusCheckingToComplete(reqMissionApprovalDto);
+        return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 
 

--- a/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
+++ b/src/main/java/com/suite/suite_study_service/mission/controller/MissionController.java
@@ -28,7 +28,7 @@ public class MissionController {
 
     @PostMapping("/mission")
     public ResponseEntity<Message> listUpMissions(@RequestBody ReqMissionListDto reqMissionListDto) {
-        return ResponseEntity.ok(new Message(StatusCode.OK,missionService.listUpMission(reqMissionListDto)));
+        return ResponseEntity.ok(new Message(StatusCode.OK,missionService.getMissions(reqMissionListDto)));
     }
 
     @PostMapping("/mission/submission")

--- a/src/main/java/com/suite/suite_study_service/mission/dto/ReqMissionApprovalDto.java
+++ b/src/main/java/com/suite/suite_study_service/mission/dto/ReqMissionApprovalDto.java
@@ -1,0 +1,18 @@
+package com.suite.suite_study_service.mission.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReqMissionApprovalDto {
+    private Long suiteRoomId;
+    private String missionName;
+
+    @Builder
+    public ReqMissionApprovalDto(Long suiteRoomId, String missionName) {
+        this.suiteRoomId = suiteRoomId;
+        this.missionName = missionName;
+    }
+}

--- a/src/main/java/com/suite/suite_study_service/mission/dto/ReqMissionApprovalDto.java
+++ b/src/main/java/com/suite/suite_study_service/mission/dto/ReqMissionApprovalDto.java
@@ -9,10 +9,12 @@ import lombok.NoArgsConstructor;
 public class ReqMissionApprovalDto {
     private Long suiteRoomId;
     private String missionName;
+    private Long memberId;
 
     @Builder
-    public ReqMissionApprovalDto(Long suiteRoomId, String missionName) {
+    public ReqMissionApprovalDto(Long suiteRoomId, String missionName, Long memberId) {
         this.suiteRoomId = suiteRoomId;
         this.missionName = missionName;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/suite/suite_study_service/mission/entity/Mission.java
+++ b/src/main/java/com/suite/suite_study_service/mission/entity/Mission.java
@@ -48,4 +48,13 @@ public class Mission {
         this.missionStatus = missionStatus;
         this.result = result;
     }
+
+    public void updateMissionStatus(MissionType missionType) {
+        this.missionStatus = missionType;
+    }
+
+    public void updateMissionStatusAndResult() {
+        this.missionStatus = MissionType.COMPLETE;
+        this.result = true;
+    }
 }

--- a/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
+++ b/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
@@ -5,9 +5,12 @@ import com.suite.suite_study_service.mission.entity.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
     List<Mission> findAllBySuiteRoomId(Long suiteRoomId);
 
     List<Mission> findAllBySuiteRoomIdAndMissionStatusAndMemberId(Long suiteRoomId, MissionType missionType, Long memberId);
+
+    Optional<Mission> findBySuiteRoomIdAndMissionNameAndMemberIdAndMissionStatus(Long suiteRoomId, String missionName, Long memberId, MissionType missionType);
 }

--- a/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
+++ b/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
@@ -12,5 +12,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     List<Mission> findAllBySuiteRoomIdAndMissionStatusAndMemberId(Long suiteRoomId, MissionType missionType, Long memberId);
 
+    Optional<Mission> findBySuiteRoomIdAndMissionNameAndMemberId(Long suiteRoomId, String missionName, Long memberId);
+
     Optional<Mission> findBySuiteRoomIdAndMissionNameAndMemberIdAndMissionStatus(Long suiteRoomId, String missionName, Long memberId, MissionType missionType);
 }

--- a/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
+++ b/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
@@ -12,6 +12,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     List<Mission> findAllBySuiteRoomIdAndMissionStatusAndMemberId(Long suiteRoomId, MissionType missionType, Long memberId);
 
+    List<Mission> findAllBySuiteRoomIdAndMissionStatus(Long suiteRoomId, MissionType missionType);
     Optional<Mission> findBySuiteRoomIdAndMissionNameAndMemberId(Long suiteRoomId, String missionName, Long memberId);
 
     Optional<Mission> findBySuiteRoomIdAndMissionNameAndMemberIdAndMissionStatus(Long suiteRoomId, String missionName, Long memberId, MissionType missionType);

--- a/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
+++ b/src/main/java/com/suite/suite_study_service/mission/repository/MissionRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface MissionRepository extends JpaRepository<Mission, Long> {
     List<Mission> findAllBySuiteRoomId(Long suiteRoomId);
 
-    List<Mission> findAllBySuiteRoomIdAndMissionStatus(Long suiteRoomId, MissionType missionType);
+    List<Mission> findAllBySuiteRoomIdAndMissionStatusAndMemberId(Long suiteRoomId, MissionType missionType, Long memberId);
 }

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
@@ -2,6 +2,7 @@ package com.suite.suite_study_service.mission.service;
 
 import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
+import com.suite.suite_study_service.mission.dto.ReqMissionListDto;
 import com.suite.suite_study_service.mission.entity.Mission;
 
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
 public interface MissionService {
     void createMission(ReqMissionDto reqMissionDto);
 
-    List<Mission> listUpMission(Long suiteRoomId, String missionTypeString);
+    List<Mission> listUpMission(ReqMissionListDto reqMissionListDto);
 
     void updateMissionStatusProgressToChecking(ReqMissionApprovalDto reqMissionApprovalDto);
 

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
@@ -1,5 +1,6 @@
 package com.suite.suite_study_service.mission.service;
 
+import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
 import com.suite.suite_study_service.mission.entity.Mission;
 
@@ -9,4 +10,8 @@ public interface MissionService {
     void createMission(ReqMissionDto reqMissionDto);
 
     List<Mission> listUpMission(Long suiteRoomId, String missionTypeString);
+
+    void updateMissionStatusProgressToChecking(ReqMissionApprovalDto reqMissionApprovalDto);
+
+    void updateMissionStatusCheckingToComplete(ReqMissionApprovalDto reqMissionApprovalDto);
 }

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionService.java
@@ -10,7 +10,8 @@ import java.util.List;
 public interface MissionService {
     void createMission(ReqMissionDto reqMissionDto);
 
-    List<Mission> listUpMission(ReqMissionListDto reqMissionListDto);
+    List<Mission> getRequestedMissions(ReqMissionListDto reqMissionListDto);
+    List<Mission> getMissions(ReqMissionListDto reqMissionListDto);
 
     void updateMissionStatusProgressToChecking(ReqMissionApprovalDto reqMissionApprovalDto);
 

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -49,8 +49,9 @@ public class MissionServiceImpl implements MissionService{
     @Override
     public List<Mission> listUpMission(Long suiteRoomId,String missionTypeString) {
         try {
+            AuthorizerDto missionReadAttemper = getSuiteAuthorizer();
             Timestamp now = new Timestamp(System.currentTimeMillis());
-            List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatus(suiteRoomId, MissionType.valueOf(missionTypeString))
+            List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatusAndMemberId(suiteRoomId, MissionType.valueOf(missionTypeString), missionReadAttemper.getMemberId())
                     .stream()
                     .filter(mission -> {
 

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -53,12 +53,12 @@ public class MissionServiceImpl implements MissionService{
             List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatus(suiteRoomId, MissionType.valueOf(missionTypeString))
                     .stream()
                     .filter(mission -> {
-                        if (MissionType.valueOf(missionTypeString) == MissionType.PROGRESS) {
-                            if (mission.getMissionDeadLine().getTime() - now.getTime() < 0) {
-                                missionRepository.deleteById(mission.getMissionId());
-                                return false;
-                            }
+
+                        if (mission.getMissionDeadLine().getTime() - now.getTime() < 0) {
+                            missionRepository.deleteById(mission.getMissionId());
+                            return false;
                         }
+
                         return true;
                     })
                     .filter(Objects::nonNull)

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -74,11 +74,23 @@ public class MissionServiceImpl implements MissionService{
 
     @Override
     public void updateMissionStatusProgressToChecking(ReqMissionApprovalDto reqMissionApprovalDto) {
+        AuthorizerDto missionApprovalRequester = getSuiteAuthorizer();
+        Boolean isHost = dashBoardRepository.findBySuiteRoomIdAndMemberId(reqMissionApprovalDto.getSuiteRoomId(), missionApprovalRequester.getMemberId()).get().isHost();
+        Mission mission = missionRepository.findBySuiteRoomIdAndMissionNameAndMemberIdAndMissionStatus(reqMissionApprovalDto.getSuiteRoomId(), reqMissionApprovalDto.getMissionName(), missionApprovalRequester.getMemberId(), MissionType.PROGRESS)
+                .orElseThrow(() -> new CustomException(StatusCode.IS_NOT_PARTICIPATED));
 
+        if(isHost) mission.updateMissionStatusAndResult();
+        mission.updateMissionStatus(MissionType.CHECKING);
     }
 
     @Override
     public void updateMissionStatusCheckingToComplete(ReqMissionApprovalDto reqMissionApprovalDto) {
+        AuthorizerDto missionApprovalRequester = getSuiteAuthorizer();
+        Boolean isHost = dashBoardRepository.findBySuiteRoomIdAndMemberId(reqMissionApprovalDto.getSuiteRoomId(), missionApprovalRequester.getMemberId()).get().isHost();
+        if(!isHost) throw new CustomException(StatusCode.FORBIDDEN);
 
+        Mission mission = missionRepository.findBySuiteRoomIdAndMissionNameAndMemberIdAndMissionStatus(reqMissionApprovalDto.getSuiteRoomId(), reqMissionApprovalDto.getMissionName(), missionApprovalRequester.getMemberId(), MissionType.CHECKING)
+                .orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND));
+        mission.updateMissionStatusAndResult();
     }
 }

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -6,6 +6,7 @@ import com.suite.suite_study_service.common.security.dto.AuthorizerDto;
 import com.suite.suite_study_service.dashboard.entity.DashBoard;
 import com.suite.suite_study_service.dashboard.repository.DashBoardRepository;
 import com.suite.suite_study_service.mission.dto.MissionType;
+import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
 import com.suite.suite_study_service.mission.entity.Mission;
 import com.suite.suite_study_service.mission.repository.MissionRepository;
@@ -68,6 +69,16 @@ public class MissionServiceImpl implements MissionService{
         } catch (Exception exception) {
             throw new CustomException(StatusCode.NOT_FOUND);
         }
+
+    }
+
+    @Override
+    public void updateMissionStatusProgressToChecking(ReqMissionApprovalDto reqMissionApprovalDto) {
+
+    }
+
+    @Override
+    public void updateMissionStatusCheckingToComplete(ReqMissionApprovalDto reqMissionApprovalDto) {
 
     }
 }

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -60,7 +60,7 @@ public class MissionServiceImpl implements MissionService{
             if(!isHost) throw new CustomException(StatusCode.FORBIDDEN);
 
             Timestamp now = new Timestamp(System.currentTimeMillis());
-            List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatus(reqMissionListDto.getSuiteRoomId(), MissionType.valueOf(reqMissionListDto.getMissionTypeString()))
+            List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatus(reqMissionListDto.getSuiteRoomId(), MissionType.CHECKING)
                     .stream()
                     .filter(mission -> isTimeOutMissions(mission, now))
                     .filter(Objects::nonNull)

--- a/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/suite/suite_study_service/mission/service/MissionServiceImpl.java
@@ -54,12 +54,10 @@ public class MissionServiceImpl implements MissionService{
             List<Mission> missionList = missionRepository.findAllBySuiteRoomIdAndMissionStatusAndMemberId(suiteRoomId, MissionType.valueOf(missionTypeString), missionReadAttemper.getMemberId())
                     .stream()
                     .filter(mission -> {
-
                         if (mission.getMissionDeadLine().getTime() - now.getTime() < 0) {
-                            missionRepository.deleteById(mission.getMissionId());
+                            mission.updateMissionStatus(MissionType.COMPLETE);
                             return false;
                         }
-
                         return true;
                     })
                     .filter(Objects::nonNull)

--- a/src/test/java/com/suite/suite_study_service/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/controller/MissionControllerTest.java
@@ -3,6 +3,7 @@ package com.suite.suite_study_service.mission.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.suite.suite_study_service.common.dto.Message;
 import com.suite.suite_study_service.dashboard.repository.DashBoardRepository;
+import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionListDto;
 import com.suite.suite_study_service.mission.mockEntity.MockDashBoard;
@@ -119,6 +120,66 @@ public class MissionControllerTest {
         //then
         Assertions.assertAll(
                 () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 요청 - 방장")
+    public void requestApprovalMissionHost() throws Exception {
+        //given
+        ReqMissionApprovalDto reqMissionApprovalDto = MockMission.getReqMissionApprovalDto("test");
+        String body = mapper.writeValueAsString(reqMissionApprovalDto);
+        //when
+        String responseBody = postRequest("/study/mission/submission", YH_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 요청 - 스터디원")
+    public void requestApprovalMissionGuest() throws Exception {
+        //given
+        ReqMissionApprovalDto reqMissionApprovalDto = MockMission.getReqMissionApprovalDto("test");
+        String body = mapper.writeValueAsString(reqMissionApprovalDto);
+        //when
+        String responseBody = postRequest("/study/mission/submission", DR_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 승인 - 방장")
+    public void approvalRequestAcceptMissionHost() throws Exception {
+        //given
+        ReqMissionApprovalDto reqMissionApprovalDto = MockMission.getReqMissionApprovalDto("test");
+        String body = mapper.writeValueAsString(reqMissionApprovalDto);
+        //when
+        String responseBody = postRequest("/study/mission/approval", YH_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 승인 - 스터디원")
+    public void approvalRequestAcceptMissionGuest() throws Exception {
+        //given
+        ReqMissionApprovalDto reqMissionApprovalDto = MockMission.getReqMissionApprovalDto("test");
+        String body = mapper.writeValueAsString(reqMissionApprovalDto);
+        //when
+        String responseBody = postRequest("/study/mission/approval", DR_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(403)
         );
     }
 

--- a/src/test/java/com/suite/suite_study_service/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/controller/MissionControllerTest.java
@@ -123,6 +123,21 @@ public class MissionControllerTest {
     }
 
     @Test
+    @DisplayName("스터디 그룹 칸반 보드 승인 요청 목록 - 방장")
+    public void listUpRequestedMissions() throws Exception {
+        //given
+        ReqMissionListDto reqMissionListDto = MockMission.getReqMissionListDto("CHECKING");
+        String body = mapper.writeValueAsString(reqMissionListDto);
+        //when
+        String responseBody = postRequest("/study/mission/admin", YH_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
+    @Test
     @DisplayName("스터디 그룹 미션 목록 - COMPLETE")
     public void listUpMissionsComplete() throws Exception {
         //given

--- a/src/test/java/com/suite/suite_study_service/mission/mockEntity/MockMission.java
+++ b/src/test/java/com/suite/suite_study_service/mission/mockEntity/MockMission.java
@@ -1,6 +1,7 @@
 package com.suite.suite_study_service.mission.mockEntity;
 
 import com.suite.suite_study_service.mission.dto.MissionType;
+import com.suite.suite_study_service.mission.dto.ReqMissionApprovalDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionDto;
 import com.suite.suite_study_service.mission.dto.ReqMissionListDto;
 import com.suite.suite_study_service.mission.entity.Mission;
@@ -55,6 +56,13 @@ public class MockMission {
         return ReqMissionListDto.builder()
                 .suiteRoomId(1L)
                 .missionTypeString(missionTypeString)
+                .build();
+    }
+
+    public static ReqMissionApprovalDto getReqMissionApprovalDto(String missionName) {
+        return ReqMissionApprovalDto.builder()
+                .suiteRoomId(1L)
+                .missionName(missionName)
                 .build();
     }
 

--- a/src/test/java/com/suite/suite_study_service/mission/mockEntity/MockMission.java
+++ b/src/test/java/com/suite/suite_study_service/mission/mockEntity/MockMission.java
@@ -59,9 +59,10 @@ public class MockMission {
                 .build();
     }
 
-    public static ReqMissionApprovalDto getReqMissionApprovalDto(String missionName) {
+    public static ReqMissionApprovalDto getReqMissionApprovalDto(String missionName, Long memberId) {
         return ReqMissionApprovalDto.builder()
                 .suiteRoomId(1L)
+                .memberId(memberId)
                 .missionName(missionName)
                 .build();
     }

--- a/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
@@ -184,6 +184,32 @@ public class MissionServiceTest {
     }
 
     @Test
+    @DisplayName("스터디 그룹 칸반 보드 관리 - 방장")
+    public void getRequestedMissions() {
+        //given
+        makeMockMissionList("test", "2023-10-15 18:00:00", MissionType.CHECKING)
+                .stream()
+                .forEach(mockMission -> {
+                    missionRepository.save(mockMission.toMission());
+                });
+        AuthorizerDto missionReadAttempter = MockAuthorizer.YH();
+        //when
+        Boolean isHost = dashBoardRepository.findBySuiteRoomIdAndMemberId(1L, missionReadAttempter.getMemberId()).get().isHost();
+        if(!isHost) {
+            assertThrows(CustomException.class, () -> {
+                throw new CustomException(StatusCode.FORBIDDEN);
+            });
+        }
+        List<Mission> assertionMissions = missionRepository.findAllBySuiteRoomIdAndMissionStatus(1L, MissionType.CHECKING);
+        //then
+        Assertions.assertAll(
+                ()-> assertThat(assertionMissions.get(0).getClass()).isEqualTo(Mission.class),
+                ()-> assertThat(assertionMissions.get(0).getMissionStatus()).isEqualTo(MissionType.CHECKING),
+                ()-> assertThat(assertionMissions.get(0).isResult()).isEqualTo(false)
+        );
+    }
+
+    @Test
     @DisplayName("스터디 그룹 미션 목록 - 기간 만료")
     public void timeOutMissions() {
         //given

--- a/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
@@ -195,10 +195,9 @@ public class MissionServiceTest {
                 .filter(mission -> {
 
                     if (mission.getMissionDeadLine().getTime() - now.getTime() < 0) {
-                        missionRepository.deleteById(mission.getMissionId());
+                        mission.updateMissionStatus(MissionType.COMPLETE);
                         return false;
                     }
-
                     return true;
                 })
                 .filter(Objects::nonNull)
@@ -208,6 +207,16 @@ public class MissionServiceTest {
         Assertions.assertAll(
                 ()-> assertThat(assertionMissions.size()).isEqualTo(0)
         );
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 요청 - 스터디원")
+    public void updateMissionStatusProgressToCheckingGuest() {
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 미션 달성 요청 - 방장")
+    public void updateMissionStatusProgressToCheckingHost() {
     }
 
     private List<MockMission> makeMockMissionList(String missionName, String missionDeadLine, MissionType missionType) {

--- a/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
@@ -73,6 +73,11 @@ public class MissionServiceTest {
                 throw new CustomException(StatusCode.FORBIDDEN);
             });
         }
+        missionRepository.findBySuiteRoomIdAndMissionNameAndMemberId(1L, "test",missionCreationAttempter.getMemberId()).ifPresent(result -> {
+                    assertThrows(CustomException.class, () -> {
+                        throw new CustomException(StatusCode.ALREADY_EXISTS_MISSION);
+                    });
+                });
 
         makeMockMissionList("test", "2023-10-15 18:00:00", MissionType.PROGRESS)
                 .stream()

--- a/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/suite/suite_study_service/mission/service/MissionServiceTest.java
@@ -180,7 +180,7 @@ public class MissionServiceTest {
                     missionRepository.save(mockMission.toMission());
                 });
         //when
-        List<Mission> assertionMissions = missionRepository.findAllBySuiteRoomIdAndMissionStatus(1L, MissionType.COMPLETE);
+        List<Mission> assertionMissions = missionRepository.findAllBySuiteRoomId(1L);
         Timestamp now = new Timestamp(System.currentTimeMillis());
         assertionMissions.stream()
                 .forEach(mission -> {


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/09/16


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 방장과 스터디원 권한에 따른 미션 달성 요청 및 승인 과정 처리
- 방장의 경우 자신의 미션 승인 요청을 보낼 시 승인 과정 없이 바로 승인처리 되도록 설계
- 기간이 지난 미션의 경우 result 를 true 로 바꾸지 않고 COMPLETE로 업데이트 하도록 목록을 불러오는 API에 기능 추가
- 방장의 경우 칸반 보드 관리 탭을 통해 CHECKING 상태의 미션들을 보고 승인을 누를 수 있음

#### 이슈 있었슈 

![스크린샷 2023-09-16 오후 9 25 35](https://github.com/SWM-TheDreaming/SUITE_STUDY_SERVICE/assets/76484900/86461506-dd3b-4c4c-92e2-d025f3edf923)

권한에 따른 에러코드 처리를 위해 테스트코드를 모두 작성해줬는데 andExpect를 isOk로 설정하면 무조건 200이 아니면 테스트 코드가 실패해서 해당 부분 수정했슈
### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
### 실제 코드

![스크린샷 2023-09-16 오후 9 26 26](https://github.com/SWM-TheDreaming/SUITE_STUDY_SERVICE/assets/76484900/a08a09f9-01de-47c2-9a9a-25332b49929c)

![스크린샷 2023-09-16 오후 9 26 40](https://github.com/SWM-TheDreaming/SUITE_STUDY_SERVICE/assets/76484900/a9e1b461-4ad7-4b19-88f5-a96e1824d7c9)
